### PR TITLE
Fix tests, some code formatting

### DIFF
--- a/as/core/core_compile.cpp
+++ b/as/core/core_compile.cpp
@@ -79,10 +79,14 @@ std::shared_ptr<ScriptModuleCompile> CoreCompile::newScriptModule(
 {
     auto language = getLanguage(resolveLanguageName(filename, language_name));
     auto language_script = language->newScript();
-    language_script->load((m_base_path / filename).string(), *m_ts_context.getContext());
+    std::filesystem::path filepath = m_base_path / filename;
+    std::filesystem::path canonicalPath = std::filesystem::weakly_canonical(filepath);
+    std::string npath = canonicalPath.make_preferred().string();
 
-    const auto interface = language_script->getInterface((m_base_path / filename).string(), *m_cpp_parser);
-    const auto externalRequires = language_script->getRequires((m_base_path / filename).string(), *m_cpp_parser);
+    language_script->load(npath, *m_ts_context.getContext());
+
+    const auto interface = language_script->getInterface(npath, *m_cpp_parser);
+    const auto externalRequires = language_script->getRequires(npath, *m_cpp_parser);
 
     if (!interface)
     {

--- a/benchmarks/benchmark_runner.h
+++ b/benchmarks/benchmark_runner.h
@@ -20,18 +20,18 @@
 namespace as::benchmark
 {
 
-struct IBenchmarkRunner
-{
-    virtual ~IBenchmarkRunner() = default;
+    struct IBenchmarkRunner
+    {
+        virtual ~IBenchmarkRunner() = default;
 
-    virtual const char* title() = 0;
-    virtual void prepare(const std::string& filename) = 0;
-    virtual double run() = 0;
-    virtual void shutdown() = 0;
+        virtual const char* title() = 0;
+        virtual void prepare(const std::string& filename) = 0;
+        virtual double run() = 0;
+        virtual void shutdown() = 0;
 
-    virtual void prepare_calls(const std::string& filename) = 0;
-    virtual double run_add(double a, double b) = 0;
-    virtual bool run_not(bool a) = 0;
-};
+        virtual void prepare_calls(const std::string& filename) = 0;
+        virtual double run_add(double a, double b) = 0;
+        virtual bool run_not(bool a) = 0;
+    };
 
-}
+} // namespace as::benchmark

--- a/benchmarks/lua/lua_jit/benchmark_runner_luajit.cpp
+++ b/benchmarks/lua/lua_jit/benchmark_runner_luajit.cpp
@@ -6,16 +6,15 @@
 #include "runner.h"
 
 extern "C" {
-#include "lua.h"
-#include "lualib.h"
-#include "lauxlib.h"
+    #include "lua.h"
+    #include "lualib.h"
+    #include "lauxlib.h"
 }
 
 extern "C"
 {
-#pragma visibility push(hidden)
-
-#pragma visibility pop
+    #pragma visibility push(hidden)
+    #pragma visibility pop
 }
 
 static lua_State* state = nullptr;
@@ -23,56 +22,50 @@ static lua_State* state = nullptr;
 namespace as::benchmark
 {
 
-std::unique_ptr<IBenchmarkRunner> getRunnerLuaJit()
-{
-    return std::make_unique<BenchmarkRunnerLuaJit>();
-}
+    std::unique_ptr<IBenchmarkRunner> getRunnerLuaJit() { return std::make_unique<BenchmarkRunnerLuaJit>(); }
 
-void BenchmarkRunnerLuaJit::prepare(const std::string& filename)
-{
-    state = luaL_newstate();
-    luaL_dostring(state, "jit.on()"); // Включение JIT
-    //luaL_dostring(state, "jit.off()"); // Отключение JIT
-    luaL_dofile(state, filename.c_str());
-}
+    void BenchmarkRunnerLuaJit::prepare(const std::string& filename)
+    {
+        state = luaL_newstate();
+        luaL_dostring(state, "jit.on()"); // Включение JIT
+        // luaL_dostring(state, "jit.off()"); // Отключение JIT
+        luaL_dofile(state, filename.c_str());
+    }
 
-double BenchmarkRunnerLuaJit::run()
-{
-    lua_getglobal(state, "test");
-    lua_call(state, 0, 1);
-    return lua_tonumber(state, -1);
-}
+    double BenchmarkRunnerLuaJit::run()
+    {
+        lua_getglobal(state, "test");
+        lua_call(state, 0, 1);
+        return lua_tonumber(state, -1);
+    }
 
-void BenchmarkRunnerLuaJit::shutdown()
-{
-    lua_close(state);
-    state = nullptr;
-}
+    void BenchmarkRunnerLuaJit::shutdown()
+    {
+        lua_close(state);
+        state = nullptr;
+    }
 
-void BenchmarkRunnerLuaJit::prepare_calls(const std::string& filename)
-{
-    prepare(filename);
-}
+    void BenchmarkRunnerLuaJit::prepare_calls(const std::string& filename) { prepare(filename); }
 
-double BenchmarkRunnerLuaJit::run_add(double a, double b)
-{
-    lua_getglobal(state, "call_add");
-    lua_pushnumber(state, a);
-    lua_pushnumber(state, b);
-    lua_call(state, 2, 1);
-    auto result = lua_tonumber(state, -1);
-    lua_pop(state, 1);
-    return result;
-}
+    double BenchmarkRunnerLuaJit::run_add(double a, double b)
+    {
+        lua_getglobal(state, "call_add");
+        lua_pushnumber(state, a);
+        lua_pushnumber(state, b);
+        lua_call(state, 2, 1);
+        auto result = lua_tonumber(state, -1);
+        lua_pop(state, 1);
+        return result;
+    }
 
-bool BenchmarkRunnerLuaJit::run_not(bool a)
-{
-    lua_getglobal(state, "call_not");
-    lua_pushboolean(state, a);
-    lua_call(state, 1, 1);
-    auto result = lua_toboolean(state, -1);
-    lua_pop(state, 1);
-    return result;
-}
+    bool BenchmarkRunnerLuaJit::run_not(bool a)
+    {
+        lua_getglobal(state, "call_not");
+        lua_pushboolean(state, a);
+        lua_call(state, 1, 1);
+        auto result = lua_toboolean(state, -1);
+        lua_pop(state, 1);
+        return result;
+    }
 
 } // namespace as::benchmark

--- a/benchmarks/lua/lua_jit/benchmark_runner_luajit.h
+++ b/benchmarks/lua/lua_jit/benchmark_runner_luajit.h
@@ -9,18 +9,18 @@
 namespace as::benchmark
 {
 
-struct BenchmarkRunnerLuaJit final : IBenchmarkRunner
-{
-    ~BenchmarkRunnerLuaJit() override = default;
+    struct BenchmarkRunnerLuaJit final : IBenchmarkRunner
+    {
+        ~BenchmarkRunnerLuaJit() override = default;
 
-    const char* title() override { return "luajit 2.1"; }
-    void prepare(const std::string& filename) override;
-    double run() override;
-    void shutdown() override;
+        const char* title() override { return "luajit 2.1"; }
+        void prepare(const std::string& filename) override;
+        double run() override;
+        void shutdown() override;
 
-    void prepare_calls(const std::string& filename) override;
-    double run_add(double a, double b) override;
-    bool run_not(bool a) override;
-};
+        void prepare_calls(const std::string& filename) override;
+        double run_add(double a, double b) override;
+        bool run_not(bool a) override;
+    };
 
-}
+} // namespace as::benchmark

--- a/test/core_compile_test.cpp
+++ b/test/core_compile_test.cpp
@@ -131,8 +131,12 @@ TEST(CoreCompileTest, BasePathTest)
 
     EXPECT_CALL(*language, init(testing::_, testing::_));
     EXPECT_CALL(*language, newScript()).WillOnce(testing::Return(language_script));
-    EXPECT_CALL(*language_script, load("some/base/path/script.foo", testing::_));
-    EXPECT_CALL(*language_script, getInterface("some/base/path/script.foo", testing::_));
+
+    std::filesystem::path canonicalPath = std::filesystem::weakly_canonical("some/base/path/script.foo");
+    std::string npath = canonicalPath.make_preferred().string();
+
+    EXPECT_CALL(*language_script, load(npath, testing::_));
+    EXPECT_CALL(*language_script, getInterface(npath, testing::_));
 
     compile->registerLanguage("foo", language);
     compile->newScriptModule("script.foo");

--- a/test/cpp_language_test.cpp
+++ b/test/cpp_language_test.cpp
@@ -168,5 +168,6 @@ TEST_F(CppLanguageTest, CompileLinkTest)
 
 TEST_F(CppLanguageTest, CompileDebugInfoTest)
 {
-    doCompileDebugInfoTest("@[_\\w]+3foo[_\\w]+");
+    //doCompileDebugInfoTest("@[_\\w]+3foo[_\\w]+");
+    doCompileDebugInfoTest(R"(@[\"\w]+\?foo[@\w]+\")");
 }

--- a/test/cpp_language_test.cpp
+++ b/test/cpp_language_test.cpp
@@ -168,6 +168,19 @@ TEST_F(CppLanguageTest, CompileLinkTest)
 
 TEST_F(CppLanguageTest, CompileDebugInfoTest)
 {
+    /*
+    * The test tries to find function definition in IR code to get DebugInfo.
+    * The following regex doesn't work with Windows + LLVM 18.1.0, but it (maybe) make sense for Unix-like + LLMV 17.06
+    * I assume that definition was:
+    * 
+    * define linkonce_odr dso_local i32 @_3foo@Test42_@UEAAHXZ_(ptr nonnull align 8 dereferenceable(8) %this) unnamed_addr #0 comdat align 2 !dbg !6 {
+    */
     //doCompileDebugInfoTest("@[_\\w]+3foo[_\\w]+");
+
+    /*
+    * For Windows + LLVM 18.1.0 definition seems like:
+    * 
+    * define linkonce_odr dso_local i32 @"?foo@Test42@@UEAAHXZ"(ptr nonnull align 8 dereferenceable(8) %this) unnamed_addr #0 comdat align 2 !dbg !6 {
+    */
     doCompileDebugInfoTest(R"(@[\"\w]+\?foo[@\w]+\")");
 }

--- a/test/features_test_fixture.cpp
+++ b/test/features_test_fixture.cpp
@@ -444,7 +444,9 @@ void FeaturesTestFixture::doCompileDebugInfoTest(const std::string& func_pattern
     auto ll_code = compile(script_name);
     EXPECT_FALSE(ll_code.empty());
 
-    auto func_dbg_entry = getDebugEntryIndex(findFunctionDebugEntry(ll_code, "linkonce_odr i32", func_pattern));
+    std::filesystem::path canonicalPath = std::filesystem::weakly_canonical(ll_code);
+    std::string npath = canonicalPath.make_preferred().string();
+    auto func_dbg_entry = getDebugEntryIndex(findFunctionDebugEntry(npath, "linkonce_odr dso_local i32", func_pattern));
     EXPECT_FALSE(func_dbg_entry.empty());
 
     auto func_file_dbg_entry = getDebugEntryIndex(findDebugAttr(ll_code, func_dbg_entry, "file"));


### PR DESCRIPTION
- Normalized paths are used for tests.
- Fized regex for CppLanguageTest.CompileDebugInfoTest
- Format some .cpp files as side effect of build